### PR TITLE
[SW-31] feat: 네이버 소셜로그인 백엔드 구현

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,5 @@ REGION=ap-northeast-2
 CORS_ALLOWED_ORIGIN=http://localhost
 
 # Oauth2 Client
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,9 +27,9 @@ dependencies {
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     // Oauth2 Client
-    // implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     // Security
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     // thymeleaf
 //    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 //    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -38,9 +38,9 @@ dependencies {
     // Rest API
     implementation 'org.springframework.boot:spring-boot-starter-web'
     // JWT
-//    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-//    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-//    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // Environment-Variable
     implementation "me.paulschwarz:spring-dotenv:4.0.0"
     // S3 client

--- a/backend/src/main/java/com/done/swim/domain/user/entity/User.java
+++ b/backend/src/main/java/com/done/swim/domain/user/entity/User.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity/* implements UserDetails*/ {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,14 +27,17 @@ public class User extends BaseTimeEntity/* implements UserDetails*/ {
     private String provider;
     private String providerId;
 
+    private String imageUrl;
+
 //    @Enumerated(EnumType.STRING)
 //    private Role role;
 
     @Builder
-    public User(String email, String nickname, String provider, String providerId) {
+    public User(String email, String nickname, String provider, String providerId, String imageUrl) {
         this.email = email;
         this.nickname = nickname;
         this.provider = provider;
         this.providerId = providerId;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/done/swim/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/done/swim/domain/user/repository/UserRepository.java
@@ -3,5 +3,9 @@ package com.done.swim.domain.user.repository;
 import com.done.swim.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
 }

--- a/backend/src/main/java/com/done/swim/sociallogin/CustomOAuth2User.java
+++ b/backend/src/main/java/com/done/swim/sociallogin/CustomOAuth2User.java
@@ -1,0 +1,38 @@
+package com.done.swim.sociallogin;
+
+import com.done.swim.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    // OAuth2User 인터페이스 구현: 인증된 사용자의 추가 속성들을 반환
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getName() {
+        return "";
+    }
+}

--- a/backend/src/main/java/com/done/swim/sociallogin/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/done/swim/sociallogin/CustomOAuth2UserService.java
@@ -1,0 +1,49 @@
+package com.done.swim.sociallogin;
+
+import com.done.swim.domain.user.entity.User;
+import com.done.swim.domain.user.repository.UserRepository;
+import com.done.swim.sociallogin.provider.NaverUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    // CustomOAuth2UserService : OAuth2 사용자 정보 처리 (사용자 인증 로직)
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 네이버 사용자 정보 DTO 변환
+        NaverUserInfo naverUserInfo = new NaverUserInfo(attributes);
+
+        // TODO : 기존 회원 확인 및 없으면 회원가입 (근데 애초에 소셜로그인만 있으면 이게 무슨 상관일까? -> 그냥 바로 userepository에 저장?)
+        User user = userRepository.findByEmail(naverUserInfo.getEmail())
+                .orElseGet(() -> {
+                    User naverUser = User.builder()
+                            .email(naverUserInfo.getEmail())
+                            .nickname(naverUserInfo.getNickname())
+                            .imageUrl(naverUserInfo.getUserImageUrl())
+                            .provider("NAVER")
+                            .providerId(naverUserInfo.getProviderId())
+                            .build();
+
+                    return userRepository.save(naverUser);
+                });
+
+        return new CustomOAuth2User(user, attributes);
+    }
+}

--- a/backend/src/main/java/com/done/swim/sociallogin/provider/NaverUserInfo.java
+++ b/backend/src/main/java/com/done/swim/sociallogin/provider/NaverUserInfo.java
@@ -1,0 +1,48 @@
+package com.done.swim.sociallogin.provider;
+
+import java.util.Map;
+
+// 네이버 OAuth2 로그인을 통해 받은 사용자 정보
+//  OAuth2UserInfo 인터페이스 -> 네이버 로그인 시 필요한 사용자 정보 추출
+public class NaverUserInfo implements OAuth2UserInfo {
+
+    // response 키 안에 사용자 정보 있음 (네이버)
+    private Map<String, Object> attributes;
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = (Map<String, Object>) attributes.get("response");
+    }
+
+//    private Map<String, Object> attributes;
+//    private Map<String, Object> response;
+//
+//    public NaverUserInfo(Map<String, Object> attributes) {
+//        this.attributes = attributes;
+//        this.response = (Map<String, Object>) attributes.get("response");
+//    }
+
+    @Override
+    public String getProvider() {
+        return "NAVER";
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("nickname");
+    }
+
+    @Override
+    public String getUserImageUrl() {
+        return (String) attributes.get("profile_image");
+    }
+}

--- a/backend/src/main/java/com/done/swim/sociallogin/provider/OAuth2UserInfo.java
+++ b/backend/src/main/java/com/done/swim/sociallogin/provider/OAuth2UserInfo.java
@@ -1,0 +1,16 @@
+package com.done.swim.sociallogin.provider;
+
+// OAuth 공통 메서드 정의하는 인터페이스
+public interface OAuth2UserInfo {
+
+    String getProvider();
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getNickname();
+
+    String getUserImageUrl();
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,7 +26,7 @@ spring.security.oauth2.client.registration.naver.client-secret=${NAVER_CLIENT_SE
 spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/api/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.client-name=Naver
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.naver.scope=name, email, profile
+spring.security.oauth2.client.registration.naver.scope=nickname, email, profile_image
 # provider
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -19,3 +19,16 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=30
 # Security Allowed Origin
 # spring.security.cors.allowed.origin=${CORS_ALLOWED_ORIGIN}
 # Social Login Properties
+#spring.security.oauth2.client.registration.naver.redirect-uri=${BASE_URL}/api/login/oauth2/code/naver
+#?? ?? BASE_URL ?? ??
+spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID}
+spring.security.oauth2.client.registration.naver.client-secret=${NAVER_CLIENT_SECRET}
+spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/api/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.client-name=Naver
+spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.naver.scope=name, email, profile
+# provider
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- ISSUE-31

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- oauth2 라이브러리 권한 설정
- 네이버 소셜로그인 관련 세팅
- oauth2userinfo 인터페이스 생성
- 백엔드에서 로그인 작동 확인 (포스트맨 이용)

## 📸 스크린샷
![{B797A365-40E5-4FE4-A1ED-0E767B706032}](https://github.com/user-attachments/assets/cd774adc-4b18-4f80-a0df-e70e85781710)
![{2F2854CF-8FDD-49EF-B13B-1725B4A5BBFE}](https://github.com/user-attachments/assets/ca23d90e-e20f-466a-8184-4feeddbacce1)


## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

- 우선 백엔드 기본 로직 구현하였고
- JWT, MySQL || Redis / 쿠키 / 시큐리티 추후 구현 예정