### PR TITLE
[SW-38] feat: 찜하기 api 구현

### DIFF
--- a/backend/src/main/java/com/done/swim/domain/poolmark/controller/PoolMarkController.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/controller/PoolMarkController.java
@@ -1,0 +1,29 @@
+package com.done.swim.domain.poolmark.controller;
+
+import com.done.swim.common.ApiResponse;
+import com.done.swim.domain.poolmark.service.PoolMarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/pools/mark")
+public class PoolMarkController {
+
+  private final PoolMarkService poolMarkService;
+
+  @PostMapping("/{poolId}")
+  public ResponseEntity<ApiResponse> createPoolMark(@PathVariable Long poolId) {
+    poolMarkService.createPoolMark(poolId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+      .body(ApiResponse
+        .ok("찜하기 성공",
+          "NO_CONTENT",
+          null));
+  }
+}

--- a/backend/src/main/java/com/done/swim/domain/poolmark/entity/PoolMark.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/entity/PoolMark.java
@@ -4,6 +4,7 @@ import com.done.swim.domain.pool.entity.Pool;
 import com.done.swim.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -11,16 +12,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PoolMark {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @JoinColumn(name = "pool_id")
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Pool pool;
+  @JoinColumn(name = "pool_id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Pool pool;
 
-    @JoinColumn(name = "user_id")
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+  @JoinColumn(name = "user_id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
 
+  @Builder
+  public PoolMark(Pool pool, User user) {
+    this.pool = pool;
+    this.user = user;
+  }
 }

--- a/backend/src/main/java/com/done/swim/domain/poolmark/repository/PoolMarkRepository.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/repository/PoolMarkRepository.java
@@ -1,7 +1,10 @@
 package com.done.swim.domain.poolmark.repository;
 
+import com.done.swim.domain.pool.entity.Pool;
 import com.done.swim.domain.poolmark.entity.PoolMark;
+import com.done.swim.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PoolMarkRepository extends JpaRepository<PoolMark, Long> {
+  boolean existsByUserAndPool(User user, Pool pool);
 }

--- a/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
@@ -1,0 +1,4 @@
+package com.done.swim.domain.poolmark.service;
+
+public class PoolMarkService {
+}

--- a/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
@@ -7,24 +7,34 @@ import com.done.swim.domain.poolmark.repository.PoolMarkRepository;
 import com.done.swim.domain.user.entity.User;
 import com.done.swim.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PoolMarkService {
+
   private final PoolMarkRepository poolMarkRepository;
   private final PoolRepository poolRepository;
   private final UserRepository userRepository;
 
+  @Transactional
   public void createPoolMark(Long poolId) {
+    log.info("Create pool mark {}", poolId);
     Pool pool = poolRepository.findById(poolId)
       .orElseThrow(() -> new IllegalArgumentException("수영장이 없습니다."));
 
     // 토큰 구현이 안되어있어서 임시로(토큰 구현 후에는 User를 파라미터로 받을 예정)
-    User user = userRepository.findById(1L)
-      .orElseThrow(() -> new IllegalArgumentException("수영장이 없습니다."));
+    User user = userRepository.findById(2L)
+      .orElseThrow(() -> new IllegalArgumentException("유저가 없습니다."));
+
+    boolean alreadyMarked = poolMarkRepository.existsByUserAndPool(user, pool);
+    if (alreadyMarked) {
+      throw new IllegalStateException("이미 찜한 수영장입니다.");
+    }
 
     PoolMark poolMark = PoolMark.builder().user(user).pool(pool).build();
     poolMarkRepository.save(poolMark);

--- a/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
@@ -23,11 +23,10 @@ public class PoolMarkService {
 
   @Transactional
   public void createPoolMark(Long poolId) {
-    log.info("Create pool mark {}", poolId);
     Pool pool = poolRepository.findById(poolId)
       .orElseThrow(() -> new IllegalArgumentException("수영장이 없습니다."));
 
-    // 토큰 구현이 안되어있어서 임시로(토큰 구현 후에는 User를 파라미터로 받을 예정)
+    // TODO: 토큰 구현이 안되어있어서 임시로(토큰 구현 후에는 User를 파라미터로 받을 예정)
     User user = userRepository.findById(2L)
       .orElseThrow(() -> new IllegalArgumentException("유저가 없습니다."));
 

--- a/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
+++ b/backend/src/main/java/com/done/swim/domain/poolmark/service/PoolMarkService.java
@@ -1,4 +1,32 @@
 package com.done.swim.domain.poolmark.service;
 
+import com.done.swim.domain.pool.entity.Pool;
+import com.done.swim.domain.pool.repository.PoolRepository;
+import com.done.swim.domain.poolmark.entity.PoolMark;
+import com.done.swim.domain.poolmark.repository.PoolMarkRepository;
+import com.done.swim.domain.user.entity.User;
+import com.done.swim.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PoolMarkService {
+  private final PoolMarkRepository poolMarkRepository;
+  private final PoolRepository poolRepository;
+  private final UserRepository userRepository;
+
+  public void createPoolMark(Long poolId) {
+    Pool pool = poolRepository.findById(poolId)
+      .orElseThrow(() -> new IllegalArgumentException("수영장이 없습니다."));
+
+    // 토큰 구현이 안되어있어서 임시로(토큰 구현 후에는 User를 파라미터로 받을 예정)
+    User user = userRepository.findById(1L)
+      .orElseThrow(() -> new IllegalArgumentException("수영장이 없습니다."));
+
+    PoolMark poolMark = PoolMark.builder().user(user).pool(pool).build();
+    poolMarkRepository.save(poolMark);
+  }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- ISSUE-1

## 📝 변경 사항
- 수영장 찜하기 API 구현
- 예외
  -  해당하는 수영장이 없는 경우
  - 이미 찜한 수영장인 경우
- 토큰 구현이 안되어있어서 임시로 User를 서비스 객체에서 불러오도록 구현
  - (토큰 구현 후에는 User를 파라미터로 받을 예정)

## 📸 스크린샷


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
