### PR TITLE
[SW-42] static ImagePath named export로 변경

### DIFF
--- a/frontend/src/components/sidebar/SideBar.jsx
+++ b/frontend/src/components/sidebar/SideBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import staticImagePath from '../../utils/staticImagePath';
+import { mypage, markPool, mypageColor, markPoolColor, home, logo } from '../../utils/staticImagePath';
 import SideBarItem from './SideBarItem';
 import { useNavigate } from 'react-router';
 
@@ -9,13 +9,13 @@ export default function SideBar() {
 
   const sideBarItems = [
     {
-      image: staticImagePath.mypage,
-      selectedImage: staticImagePath.mypageColor,
+      image: mypage,
+      selectedImage: mypageColor,
       title: '마이페이지',
     },
     {
-      image: staticImagePath.markPool,
-      selectedImage: staticImagePath.markPoolColor,
+      image: markPool,
+      selectedImage: markPoolColor,
       title: '내가 찜한 수영장',
     },
   ];
@@ -38,7 +38,7 @@ export default function SideBar() {
     <>
       <div className="border-gray03 border-[0.5px] w-30 flex flex-col items-center h-full">
         <img
-          src={staticImagePath.logo}
+          src={logo}
           alt=""
           className="w-2/3 mt-5 cursor-pointer select-none"
           draggable={false}
@@ -60,7 +60,7 @@ export default function SideBar() {
         })}
 
         <img
-          src={staticImagePath.home}
+          src={home}
           alt=""
           className="h-12 aspect-square absolute bottom-10 cursor-pointer select-none"
           draggable={false}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,6 @@
-@import 'tailwindcss';
-
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css');
+
+@import 'tailwindcss';
 
 @theme {
   --color-blue01: #0085ff;

--- a/frontend/src/utils/staticImagePath.js
+++ b/frontend/src/utils/staticImagePath.js
@@ -1,44 +1,20 @@
-import logo from '../assets/logo.svg';
-import home from '../assets/home.svg';
-import contactUs from '../assets/contactUs.svg';
-import contactUsColor from '../assets/contactUs.svg'
-import kewordReview from '../assets/keywordReview.svg';
-import kewordReviewColor from '../assets/keywordReviewColor.svg';
-import markPool from '../assets/markPool.svg';
-import markPoolColor from '../assets/markPoolColor.svg';
-import mark from '../assets/mark.svg';
-import markColor from '../assets/markColor.svg';
-import more from '../assets/more.svg';
-import myReview from '../assets/myReview.svg';
-import myReviewColor from '../assets/myReviewColor.svg';
-import mypage from '../assets/mypage.svg';
-import mypageColor from '../assets/mypageColor.svg';
-import noContent from '../assets/noContent.svg';
-import pictureColor from '../assets/pictureColor.svg';
-import profile from '../assets/profile.svg';
-import swimming from '../assets/swimming.svg';
-import wave from '../assets/wave.svg';
-
-
-export default {
-  logo,
-  home,
-  contactUs,
-  contactUsColor,
-  kewordReview,
-  kewordReviewColor,
-  markPool,
-  markPoolColor,
-  mark,
-  markColor,
-  more,
-  myReview,
-  myReviewColor,
-  mypage,
-  mypageColor,
-  noContent,
-  pictureColor,
-  profile,
-  swimming,
-  wave,
-};
+export { default as logo } from '../assets/logo.svg';
+export { default as home } from '../assets/home.svg';
+export { default as contactUs } from '../assets/contactUs.svg';
+export { default as contactUsColor } from '../assets/contactUsColor.svg';
+export { default as kewordReview } from '../assets/keywordReview.svg';
+export { default as kewordReviewColor } from '../assets/keywordReviewColor.svg';
+export { default as markPool } from '../assets/markPool.svg';
+export { default as markPoolColor } from '../assets/markPoolColor.svg';
+export { default as mark } from '../assets/mark.svg';
+export { default as markColor } from '../assets/markColor.svg';
+export { default as more } from '../assets/more.svg';
+export { default as myReview } from '../assets/myReview.svg';
+export { default as myReviewColor } from '../assets/myReviewColor.svg';
+export { default as mypage } from '../assets/mypage.svg';
+export { default as mypageColor } from '../assets/mypageColor.svg';
+export { default as noContent } from '../assets/noContent.svg';
+export { default as pictureColor } from '../assets/pictureColor.svg';
+export { default as profile } from '../assets/profile.svg';
+export { default as swimming } from '../assets/swimming.svg';
+export { default as wave } from '../assets/wave.svg';


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- SW-42

## 📝 변경 사항
- static ImagePath named export로 변경

아래처럼 import해서 쓰시면 됩니다.
```javascript
import { mypage, markPool, mypageColor, markPoolColor, home, logo } from '../../utils/staticImagePath';
```

## 📸 스크린샷


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항