### PR TITLE
[SW-107] 최근 로그인 이력 카카오 네이버 구분

### DIFF
--- a/backend/src/main/java/com/done/swim/domain/submittedimage/dto/responsedto/SubmittedImageResponseDto.java
+++ b/backend/src/main/java/com/done/swim/domain/submittedimage/dto/responsedto/SubmittedImageResponseDto.java
@@ -1,8 +1,6 @@
 package com.done.swim.domain.submittedimage.dto.responsedto;
 
-import com.done.swim.domain.pool.entity.Pool;
 import com.done.swim.domain.submittedimage.entity.SubmittedImage;
-import com.done.swim.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +12,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SubmittedImageResponseDto {
     private Long id;
-    private Pool pool;
-    private User user;
+    private Long poolId;
+    private Long userId;
     private String imageUrl;
     private String originalName;
 
@@ -23,8 +21,8 @@ public class SubmittedImageResponseDto {
 
         return SubmittedImageResponseDto.builder()
                 .id(submittedImage.getId())
-                .pool(submittedImage.getPool())
-                .user(submittedImage.getUser())
+                .poolId(submittedImage.getPool().getId())
+                .userId(submittedImage.getUser().getId())
                 .imageUrl(submittedImage.getImageUrl())
                 .originalName(submittedImage.getOriginalName())
                 .build();

--- a/backend/src/main/java/com/done/swim/domain/user/entity/User.java
+++ b/backend/src/main/java/com/done/swim/domain/user/entity/User.java
@@ -1,24 +1,10 @@
 package com.done.swim.domain.user.entity;
 
 import com.done.swim.common.BaseTimeEntity;
-
 import com.done.swim.domain.poolmark.entity.PoolMark;
 import com.done.swim.domain.poolreview.entity.PoolReview;
 import com.done.swim.domain.submittedimage.entity.SubmittedImage;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import jakarta.persistence.*;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 
 @Entity
@@ -72,6 +59,12 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.provider = provider;
         this.providerId = providerId;
         this.imageUrl = imageUrl;
+    }
+
+    // provider 업데이트 메서드
+    public void updateProvider(String provider, String providerId) {
+        this.provider = provider;
+        this.providerId = providerId;
     }
 
     // UserDetails 인터페이스 구현

--- a/backend/src/main/java/com/done/swim/oauth2/provider/GithubUserInfo.java
+++ b/backend/src/main/java/com/done/swim/oauth2/provider/GithubUserInfo.java
@@ -1,7 +1,6 @@
 package com.done.swim.oauth2.provider;
 
 import lombok.Setter;
-
 import java.util.Map;
 
 public class GithubUserInfo implements OAuth2UserInfo {
@@ -34,6 +33,7 @@ public class GithubUserInfo implements OAuth2UserInfo {
         return email;
     }
 
+    // 깃허브에서 login이란 이름으로 이름 제공함
     @Override
     public String getNickname() {
         return (String) attributes.get("login");


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- ISSUE-107

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 
		주석으로 PR에 남지 않습니다 -->

- 동일 이메일로 로그인 시 최근 로그인 이력 안 뜨는 오류가 있어서
- 동일 이메일로 로그인 시 PROVIDER 업데이트 (provider, providerId)

## 📸 스크린샷


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트
- [x] 로컬에서 출동확인

## 📌 참고 사항

- 